### PR TITLE
CI running complete build and tests with hcdev and holoconsole

### DIFF
--- a/.travis
+++ b/.travis
@@ -1,0 +1,11 @@
+services:
+  - docker
+
+dist: trusty
+
+jobs:
+  include:
+    - stage: "All"
+      name: "Tests"
+      install: docker pull holochain/app-spec-rust:master
+      script: . docker/run-update && docker/run-test

--- a/docker/Dockerfile.app-spec-rust
+++ b/docker/Dockerfile.app-spec-rust
@@ -2,12 +2,15 @@ FROM holochain/holochain-rust:develop
 
 RUN apt-get update && apt-get install --yes \
   git \
-  qtdeclarative5-dev
+  qtdeclarative5-dev \
+  nodejs \
+  npm
 
 RUN chown ${DOCKER_BUILD_USER} /holochain
 USER ${DOCKER_BUILD_USER}
 
 RUN rustup default nightly
+RUN rustup target add wasm32-unknown-unknown
 WORKDIR /holochain
 RUN git clone https://github.com/holochain/holochain-cmd
 RUN git clone https://github.com/holochain/holosqape

--- a/docker/Dockerfile.app-spec-rust
+++ b/docker/Dockerfile.app-spec-rust
@@ -1,0 +1,32 @@
+FROM holochain/holochain-rust:develop
+
+RUN apt-get update && apt-get install --yes \
+  git \
+  qtdeclarative5-dev
+
+RUN chown ${DOCKER_BUILD_USER} /holochain
+USER ${DOCKER_BUILD_USER}
+
+RUN rustup default nightly
+WORKDIR /holochain
+RUN git clone https://github.com/holochain/holochain-cmd
+RUN git clone https://github.com/holochain/holosqape
+
+ENV PATH "/holochain/holochain-cmd/target/release:/holochain/holosqape/holoconsole:$PATH"
+
+WORKDIR /holochain/holochain-cmd
+RUN cargo +nightly build --release
+WORKDIR /holochain/holosqape
+RUN git submodule init
+RUN git submodule update
+WORKDIR /holochain/holosqape/holochain-rust
+RUN cargo +$TOOLS_NIGHTLY build
+WORKDIR /holochain/holosqape/bindings
+RUN qmake
+RUN make
+WORKDIR /holochain/holosqape/holoconsole
+RUN qmake
+RUN make
+
+WORKDIR /holochain
+USER root

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -f docker/Dockerfile.app-spec-rust -t holochain/app-spec-rust:master "$@" .

--- a/docker/entry
+++ b/docker/entry
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -n "$HOST_UID" ]; then
+  OLDID=`id -u holochain`
+  if [ "$OLDID" != "$HOST_UID" ]; then
+    usermod -u "$HOST_UID" holochain
+    groupmod -g "$HOST_UID" holochain
+    usermod -g "$HOST_UID" holochain
+    chown -R -h "$HOST_UID":"$HOST_UID" /home/holochain
+  fi
+fi
+
+gosu holochain "$@"

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Detect whether we are on a OSX host, determine host user ID
+# This gives a warning on linux that must be ignored.
+if [ "$(uname)" = "Linux" ]; then
+  # linux detected
+  HOST_UID=$UID
+else
+  # There is nothing we need to do in this case. For the holochain user, everything below app/
+  # appears to belong to him. This is a quirk of Docker for Mac.
+  HOST_UID=
+fi
+
+export HOST_UID
+
+docker run -h holochain \
+  -e HOST_UID \
+  -v `pwd`:/holochain/app-spec-rust \
+  -v $HOME/.cargo/registry:/home/holochain/.cargo/registry \
+  --rm -it holochain/app-spec-rust:master ./app-spec-rust/docker/entry "$@"

--- a/docker/run-test
+++ b/docker/run-test
@@ -1,0 +1,2 @@
+#!/bin/bash
+./docker/run /holochain/app-spec-rust/docker/test

--- a/docker/run-update
+++ b/docker/run-update
@@ -1,0 +1,2 @@
+#!/bin/bash
+./docker/run /holochain/app-spec-rust/docker/update

--- a/docker/test
+++ b/docker/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /holochain/app-spec-rust
+./build_and_test.sh

--- a/docker/update
+++ b/docker/update
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cd /holochain/holochain-cmd
+git pull
+cargo +nightly build --release
+
+cd /holochain/holosqape
+git pull
+git submodule update
+
+cd /holochain/holosqape/holochain-rust
+git pull
+cargo +$TOOLS_NIGHTLY build
+
+cd /holochain/holosqape/bindings
+git pull
+qmake
+make
+
+cd /holochain/holosqape/holoconsole
+git pull
+qmake
+make

--- a/docker/update
+++ b/docker/update
@@ -2,6 +2,7 @@
 
 cd /holochain/holochain-cmd
 git pull
+cargo update
 cargo +nightly build --release
 
 cd /holochain/holosqape
@@ -10,6 +11,7 @@ git submodule update
 
 cd /holochain/holosqape/holochain-rust
 git pull
+cargo update
 cargo +$TOOLS_NIGHTLY build
 
 cd /holochain/holosqape/bindings


### PR DESCRIPTION
closes #3 

Docker image that sits on top of our holochain/holochain-rust image and comes with clones of https://github.com/holochain/holochain-cmd and https://github.com/holochain/holosqape.

Travis is configured to run:
* `docker/run-update`: pulls and builds the newest versions of hcdev, holoconsole and holochain.
* `docker/run-tests`: runs `build_and_test.sh`