### PR TITLE
Implement get_links

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,9 @@ test('create_post', (t) => {
 test('posts_by_agent', (t) => {
   t.plan(1)
 
+  // ONCE https://github.com/holochain/hdk-rust/pull/31/files
+  // is merged in, this PR will break, then we need to fix it :p
+
   const agent = "Bob"
   const params = JSON.stringify({agent})
 


### PR DESCRIPTION
Once https://github.com/holochain/hdk-rust/pull/31 goes in, the tests on this branch will fail, we need to make them pass

Part of the proposed dev camp spec
https://github.com/holochain/hdk-rust/projects/1?fullscreen=true

https://github.com/holochain/hdk-rust/issues/27