### PR TITLE
Get with options

### DIFF
--- a/zomes/blog/code/src/hc_lifecycle_capability.rs
+++ b/zomes/blog/code/src/hc_lifecycle_capability.rs
@@ -9,6 +9,6 @@
 // about these specifics.
 
 #[no_mangle]
-pub extern "C" fn genesis(_offset: i32) -> i32{
+pub extern "C" fn genesis(_offset: i32) -> i32 {
     0
 }

--- a/zomes/blog/code/src/post_validations.rs
+++ b/zomes/blog/code/src/post_validations.rs
@@ -15,11 +15,11 @@
 #[derive(Serialize, Deserialize)]
 struct Post {
     content: String,
-    date_created: String
+    date_created: String,
 }
 
 #[no_mangle]
-pub extern "C" fn validate_commit(_offset: i32) -> i32{
+pub extern "C" fn validate_commit(_offset: i32) -> i32 {
     0
 }
 


### PR DESCRIPTION
This change to the app spec has get_entry requiring an Options parameter, as well as returning the GetEntryResult instead of the the entry itself.  This sets us up for all the parameterization that was available in holochain-proto and the ability to return more than just then entry including crud status and sources, etc.