### PR TITLE
Links round-trip & AGENT_KEY_HASH

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,23 @@ test('posts_by_agent', (t) => {
 
   const result = app.call("blog", "main", "posts_by_agent", params)
 
-  t.equal(result, JSON.stringify({"error":"FunctionNotImplemented"}))
+  t.equal(result, JSON.stringify({"post_hashes":[]}))
+})
+
+test('my_posts', (t) => {
+  t.plan(1)
+
+  app.call("blog", "main", "create_post",
+    JSON.stringify({"content": "Holo world", "in_reply_to": ""})
+  )
+
+  app.call("blog", "main", "create_post",
+    JSON.stringify({"content": "Another post", "in_reply_to": ""})
+  )
+
+  const result = app.call("blog", "main", "my_posts", JSON.stringify({}))
+
+  t.equal(result, JSON.stringify({"post_hashes":["asdf", "asdf"]}))
 })
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ test('my_posts', (t) => {
 
   const result = app.call("blog", "main", "my_posts", JSON.stringify({}))
 
-  t.equal(result, JSON.stringify({"post_hashes":["asdf", "asdf"]}))
+  t.equal(result, JSON.stringify({"post_hashes":["Qme9vatSfYs7MpejUUrheYYUA1B2TYdVBDycuoimtHudMP","QmdJHaznj5rAtMV5nXLK87tdCBoc2NJRtQW4r3w7LZ6HSg"]}))
 })
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -48,8 +48,9 @@ test('my_posts', (t) => {
   )
 
   const result = app.call("blog", "main", "my_posts", JSON.stringify({}))
-
-  t.equal(result, JSON.stringify({"post_hashes":["Qme9vatSfYs7MpejUUrheYYUA1B2TYdVBDycuoimtHudMP","QmdJHaznj5rAtMV5nXLK87tdCBoc2NJRtQW4r3w7LZ6HSg"]}))
+  const ordering1 = result == JSON.stringify({"post_hashes":["Qme9vatSfYs7MpejUUrheYYUA1B2TYdVBDycuoimtHudMP","QmdJHaznj5rAtMV5nXLK87tdCBoc2NJRtQW4r3w7LZ6HSg"]})
+  const ordering2 = result == JSON.stringify({"post_hashes":["QmdJHaznj5rAtMV5nXLK87tdCBoc2NJRtQW4r3w7LZ6HSg","Qme9vatSfYs7MpejUUrheYYUA1B2TYdVBDycuoimtHudMP"]})
+  t.ok(ordering1 || ordering2, "Did not get post hashes [\"QmdJHaznj5rAtMV5nXLK87tdCBoc2NJRtQW4r3w7LZ6HSg\",\"Qme9vatSfYs7MpejUUrheYYUA1B2TYdVBDycuoimtHudMP\"] in any ordering")
 })
 
 

--- a/zomes/blog/capabilities/main/manifest.json
+++ b/zomes/blog/capabilities/main/manifest.json
@@ -24,6 +24,13 @@
       ]
     },
     {
+      "name": "my_posts",
+      "inputs": [],
+      "outputs": [
+        {"name": "post_hashes", "type": "array"}
+      ]
+    },
+    {
       "name": "get_post",
       "inputs": [
         {"name": "post_hash", "type": "hash"}

--- a/zomes/blog/code/src/main_capability.rs
+++ b/zomes/blog/code/src/main_capability.rs
@@ -4,7 +4,7 @@ use hdk::{
         GetEntryOptions, GetResultStatus,
     },
     holochain_wasm_utils::holochain_core_types::hash::HashString,
-    AGENT_KEY_HASH,
+    AGENT_INITIAL_HASH,
 };
 
 zome_functions! {
@@ -18,7 +18,7 @@ zome_functions! {
         )) {
             Ok(post_hash) => {
                 let link_result = hdk::link_entries(
-                    &HashString::from(AGENT_KEY_HASH.to_string()),
+                    &HashString::from(AGENT_INITIAL_HASH.to_string()),
                     &post_hash,
                     "authored_posts"
                 );
@@ -48,7 +48,7 @@ zome_functions! {
     }
 
     my_posts: | | {
-        match hdk::get_links(&HashString::from(AGENT_KEY_HASH.to_string()), "authored_posts") {
+        match hdk::get_links(&HashString::from(AGENT_INITIAL_HASH.to_string()), "authored_posts") {
             Ok(result) => json!({"post_hashes": result.links}),
             Err(hdk_error) => hdk_error.to_json(),
         }

--- a/zomes/blog/code/src/main_capability.rs
+++ b/zomes/blog/code/src/main_capability.rs
@@ -49,7 +49,7 @@ zome_functions! {
 
     my_posts: | | {
         match hdk::get_links(&HashString::from(AGENT_KEY_HASH.to_string()), "authored_posts") {
-            Ok(result) => json!({"post_hashes": &HashString::from(AGENT_KEY_HASH.to_string())}),
+            Ok(result) => json!({"post_hashes": result.links}),
             Err(hdk_error) => hdk_error.to_json(),
         }
     }

--- a/zomes/blog/code/src/main_capability.rs
+++ b/zomes/blog/code/src/main_capability.rs
@@ -17,16 +17,20 @@ zome_functions! {
             }
         )) {
             Ok(post_hash) => {
-                let _ = hdk::link_entries(
-                    HashString::from(AGENT_KEY_HASH.to_string()),
-                    post_hash.clone(),
+                let link_result = hdk::link_entries(
+                    &HashString::from(AGENT_KEY_HASH.to_string()),
+                    &post_hash,
                     "authored_posts"
                 );
+
+                if link_result.is_err() {
+                    return json!({"link error": link_result.err().unwrap()})
+                }
 
                 let in_reply_to = in_reply_to;
                 if !in_reply_to.to_string().is_empty() {
                     if let Ok(_) = hdk::get_entry(in_reply_to.clone(), GetEntryOptions{}) {
-                        hdk::link_entries(in_reply_to, post_hash.clone(), "comments");
+                        let _ = hdk::link_entries(&in_reply_to, &post_hash, "comments");
                     }
                 }
 
@@ -37,8 +41,15 @@ zome_functions! {
     }
 
     posts_by_agent: |agent: HashString| {
-        match hdk::get_links(agent, "authored_posts") {
-            Ok(links) => json!({"post_hashes": links}),
+        match hdk::get_links(&agent, "authored_posts") {
+            Ok(result) => json!({"post_hashes": result.links}),
+            Err(hdk_error) => hdk_error.to_json(),
+        }
+    }
+
+    my_posts: | | {
+        match hdk::get_links(&HashString::from(AGENT_KEY_HASH.to_string()), "authored_posts") {
+            Ok(result) => json!({"post_hashes": &HashString::from(AGENT_KEY_HASH.to_string())}),
             Err(hdk_error) => hdk_error.to_json(),
         }
     }


### PR DESCRIPTION
This is a real-world application of links that uses ~~`AGENT_KEY_HASH`~~ (switched to `AGENT_INITIAL_HASH for now, but as we discussed will change name to `AGENT_ADDRESS`) to hang all *my posts* onto that hash.

Added function `my_posts` that retrieves those links.

Is currently not working because the DHT does not allow a link it has not entry for and since agent entries are in the workings...